### PR TITLE
FEATURE: Introduce threshold for failed jobs for index switching

### DIFF
--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -7,7 +7,7 @@ Flowpack:
 
       # Number of failed jobs accepted to switch the alias to the new index
       # -1 means, accept any number of failures
-      acceptedFailedJobs: -1
+      acceptedFailedJobs: 0
 
   JobQueue:
     Common:

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -4,6 +4,11 @@ Flowpack:
       enableLiveAsyncIndexing: true
       # Change size of single batch jobs via this setting
       batchSize: 500
+
+      # Number of failed jobs accepted to switch the alias to the new index
+      # -1 means, accept any number of failures
+      acceptedFailedJobs: -1
+
   JobQueue:
     Common:
       presets:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ You can use this CLI command to process indexing job:
 
 # Supervisord configuration
 
-You can use tools like ```supervisord``` to manage long runing process. Bellow you can
-found a basic configuration:
+You can use tools like ```supervisord``` to manage long running processes. Bellow you can find a basic configuration:
 
     [supervisord]
 


### PR DESCRIPTION
This change introduces a new setting to set a number of accepted failed jobs.
The index is only switched if not more than the configured number of
failed jobs occurs in the queue.

Close: #33 