### PR TITLE
BUGFIX: Make sure persistence check is correct

### DIFF
--- a/Classes/Domain/Service/FakeNodeDataFactory.php
+++ b/Classes/Domain/Service/FakeNodeDataFactory.php
@@ -84,7 +84,7 @@ class FakeNodeDataFactory
         $nodeData->setRemoved(true);
 
         // Ensure, the fake-node is not persisted
-        if ($this->persistenceManager->isNewObject($nodeData)) {
+        if (false === $this->persistenceManager->isNewObject($nodeData)) {
             $this->persistenceManager->remove($nodeData);
         }
 

--- a/Classes/Domain/Service/FakeNodeDataFactory.php
+++ b/Classes/Domain/Service/FakeNodeDataFactory.php
@@ -84,9 +84,7 @@ class FakeNodeDataFactory
         $nodeData->setRemoved(true);
 
         // Ensure, the fake-node is not persisted
-        if ($this->persistenceManager->isNewObject($nodeData) === false) {
-            $this->persistenceManager->remove($nodeData);
-        }
+        $this->persistenceManager->remove($nodeData);
 
         return $nodeData;
     }

--- a/Classes/Domain/Service/FakeNodeDataFactory.php
+++ b/Classes/Domain/Service/FakeNodeDataFactory.php
@@ -84,7 +84,7 @@ class FakeNodeDataFactory
         $nodeData->setRemoved(true);
 
         // Ensure, the fake-node is not persisted
-        if (false === $this->persistenceManager->isNewObject($nodeData)) {
+        if ($this->persistenceManager->isNewObject($nodeData) === false) {
             $this->persistenceManager->remove($nodeData);
         }
 


### PR DESCRIPTION
We updated to the latest 4.x QueueIndexerand still notice fake-nodes being created.

I'm not that much into the details of doctrine, but the docs from [PersistenceManager.php](https://github.com/neos/flow-development-collection/blob/1a4e6ba72d6e20821a8c7e97a9fe109e6013eccb/Neos.Flow/Classes/Persistence/Doctrine/PersistenceManager.php#L142) suggest to check for `false` if the nodeData is in the repository - instead of `true`.

@daniellienert Could you have a look at this please and create a new (4.x) release if you think this makes sense.