### PR TITLE
BUGFIX: Use NodeIndexerInterface in IndexingJob

### DIFF
--- a/Classes/AbstractIndexingJob.php
+++ b/Classes/AbstractIndexingJob.php
@@ -11,12 +11,12 @@ namespace Flowpack\ElasticSearch\ContentRepositoryQueueIndexer;
  * source code.
  */
 
-use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
 use Flowpack\ElasticSearch\ContentRepositoryQueueIndexer\Domain\Repository\NodeDataRepository;
 use Flowpack\ElasticSearch\ContentRepositoryQueueIndexer\Domain\Service\FakeNodeDataFactory;
 use Flowpack\JobQueue\Common\Job\JobInterface;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
+use Neos\ContentRepository\Search\Indexer\NodeIndexerInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Utility\Algorithms;
 use Psr\Log\LoggerInterface;
@@ -31,7 +31,7 @@ abstract class AbstractIndexingJob implements JobInterface
     protected $logger;
 
     /**
-     * @var NodeIndexer
+     * @var NodeIndexerInterface
      * @Flow\Inject
      */
     protected $nodeIndexer;


### PR DESCRIPTION
- use the NodeIndexerInterface, so it can be overwritten in the Objects.yaml