### PR TITLE
BUGFIX: NodeDataRepository uses PersistenceObjectIdentifier to improve query speed

### DIFF
--- a/Classes/Command/NodeIndexQueueCommandController.php
+++ b/Classes/Command/NodeIndexQueueCommandController.php
@@ -276,14 +276,14 @@ class NodeIndexQueueCommandController extends CommandController
         $this->outputLine('<info>++</info> Indexing %s workspace', [$workspaceName]);
         $nodeCounter = 0;
         $offset = 0;
-        $lastPOD = null;
+        $lastPOI = null;
         while (true) {
-            $iterator = $this->nodeDataRepository->findAllBySiteAndWorkspace($workspaceName, $lastPOD, $this->batchSize);
+            $iterator = $this->nodeDataRepository->findAllBySiteAndWorkspace($workspaceName, $lastPOI, $this->batchSize);
 
             $jobData = [];
 
             foreach ($this->nodeDataRepository->iterate($iterator) as $data) {
-                $lastPOD = $data['persistenceObjectIdentifier'];
+                $lastPOI = $data['persistenceObjectIdentifier'];
 
                 $jobData[] = [
                     'persistenceObjectIdentifier' => $data['persistenceObjectIdentifier'],

--- a/Classes/Command/NodeIndexQueueCommandController.php
+++ b/Classes/Command/NodeIndexQueueCommandController.php
@@ -276,12 +276,15 @@ class NodeIndexQueueCommandController extends CommandController
         $this->outputLine('<info>++</info> Indexing %s workspace', [$workspaceName]);
         $nodeCounter = 0;
         $offset = 0;
+        $lastPOD = null;
         while (true) {
-            $iterator = $this->nodeDataRepository->findAllBySiteAndWorkspace($workspaceName, $offset, $this->batchSize);
+            $iterator = $this->nodeDataRepository->findAllBySiteAndWorkspace($workspaceName, $lastPOD, $this->batchSize);
 
             $jobData = [];
 
             foreach ($this->nodeDataRepository->iterate($iterator) as $data) {
+                $lastPOD = $data['persistenceObjectIdentifier'];
+
                 $jobData[] = [
                     'persistenceObjectIdentifier' => $data['persistenceObjectIdentifier'],
                     'identifier' => $data['identifier'],

--- a/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Classes/Domain/Repository/NodeDataRepository.php
@@ -44,12 +44,12 @@ class NodeDataRepository extends Repository
 
     /**
      * @param string $workspaceName
-     * @param string $lastPOD
+     * @param string $lastPOI
      * @param int $maxResults
      * @return IterableResult
      * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception
      */
-    public function findAllBySiteAndWorkspace(string $workspaceName, string $lastPOD=null, int $maxResults = 1000): IterableResult
+    public function findAllBySiteAndWorkspace(string $workspaceName, string $lastPOI=null, int $maxResults = 1000): IterableResult
     {
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = $this->entityManager->createQueryBuilder();
@@ -63,8 +63,8 @@ class NodeDataRepository extends Repository
             ])
             ->orderBy('n.Persistence_Object_Identifier');
 
-        if (!empty($lastPOD)) {
-            $queryBuilder->andWhere($queryBuilder->expr()->gt('n.Persistence_Object_Identifier', $queryBuilder->expr()->literal($lastPOD)));
+        if (!empty($lastPOI)) {
+            $queryBuilder->andWhere($queryBuilder->expr()->gt('n.Persistence_Object_Identifier', $queryBuilder->expr()->literal($lastPOI)));
         }
 
         $excludedNodeTypes = array_keys(array_filter($this->nodeTypeIndexingConfiguration->getIndexableConfiguration(), static function($value) {

--- a/Classes/Domain/Repository/NodeDataRepository.php
+++ b/Classes/Domain/Repository/NodeDataRepository.php
@@ -44,24 +44,28 @@ class NodeDataRepository extends Repository
 
     /**
      * @param string $workspaceName
-     * @param int $firstResult
+     * @param string $lastPOD
      * @param int $maxResults
      * @return IterableResult
      * @throws \Flowpack\ElasticSearch\ContentRepositoryAdaptor\Exception
      */
-    public function findAllBySiteAndWorkspace(string $workspaceName, int $firstResult = 0, int $maxResults = 1000): IterableResult
+    public function findAllBySiteAndWorkspace(string $workspaceName, string $lastPOD=null, int $maxResults = 1000): IterableResult
     {
         /** @var QueryBuilder $queryBuilder */
         $queryBuilder = $this->entityManager->createQueryBuilder();
         $queryBuilder->select('n.Persistence_Object_Identifier persistenceObjectIdentifier, n.identifier identifier, n.dimensionValues dimensions, n.nodeType nodeType, n.path path')
             ->from(NodeData::class, 'n')
             ->where('n.workspace = :workspace AND n.removed = :removed AND n.movedTo IS NULL')
-            ->setFirstResult((integer)$firstResult)
             ->setMaxResults((integer)$maxResults)
             ->setParameters([
                 ':workspace' => $workspaceName,
                 ':removed' => false,
-            ]);
+            ])
+            ->orderBy('n.Persistence_Object_Identifier');
+
+        if (!empty($lastPOD)) {
+            $queryBuilder->andWhere($queryBuilder->expr()->gt('n.Persistence_Object_Identifier', $queryBuilder->expr()->literal($lastPOD)));
+        }
 
         $excludedNodeTypes = array_keys(array_filter($this->nodeTypeIndexingConfiguration->getIndexableConfiguration(), static function($value) {
             return !$value;


### PR DESCRIPTION
This PR reduces runtime of the `buildCommand` by around 90%.

On a larger project, with ~350.000 nodes in the nodedatatable, it takes around 50 minutes to fill the build queue using `./flow nodeindexqueue:build --workspace live`. With this PR, it takes around 4 minutes.

## What I did

Instead of using `OFFSET`, I use a condition on the persistence object identifier and sort the nodedata table using the poi. This method allows the DB to provide the results in constant time for every query.

## Why does it work

The previous query, uses OFFSET, which means the database needs to search through the table as the offset increases. That's why the build command is slowing down as the offset increases. The DB needs to search for the correct offset every time.  
To avoid this problem, we can make use of the primary key instead of the offset and start right after the last used pid to search for the next batch.