### PR TITLE
Revert "BUGFIX: Use NodeIndexerInterface in IndexingJob"

### DIFF
--- a/Classes/AbstractIndexingJob.php
+++ b/Classes/AbstractIndexingJob.php
@@ -11,12 +11,12 @@ namespace Flowpack\ElasticSearch\ContentRepositoryQueueIndexer;
  * source code.
  */
 
+use Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer;
 use Flowpack\ElasticSearch\ContentRepositoryQueueIndexer\Domain\Repository\NodeDataRepository;
 use Flowpack\ElasticSearch\ContentRepositoryQueueIndexer\Domain\Service\FakeNodeDataFactory;
 use Flowpack\JobQueue\Common\Job\JobInterface;
 use Neos\ContentRepository\Domain\Factory\NodeFactory;
 use Neos\ContentRepository\Domain\Service\ContextFactoryInterface;
-use Neos\ContentRepository\Search\Indexer\NodeIndexerInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Utility\Algorithms;
 use Psr\Log\LoggerInterface;
@@ -31,7 +31,7 @@ abstract class AbstractIndexingJob implements JobInterface
     protected $logger;
 
     /**
-     * @var NodeIndexerInterface
+     * @var NodeIndexer
      * @Flow\Inject
      */
     protected $nodeIndexer;


### PR DESCRIPTION
The queueindexer package wires this interface to 

```
Neos\ContentRepository\Search\Indexer\NodeIndexerInterface:
  className: Flowpack\ElasticSearch\ContentRepositoryQueueIndexer\Indexer\NodeIndexer
```

instead of 

```
Neos\ContentRepository\Search\Indexer\NodeIndexerInterface:
  className: 'Flowpack\ElasticSearch\ContentRepositoryAdaptor\Indexer\NodeIndexer'
```

This leads to the weird behavior of spamming the live queue or spawning unlimited proccesses when using the fake queueu.

Reverts Flowpack/Flowpack.ElasticSearch.ContentRepositoryQueueIndexer#48