### PR TITLE
Fix: Indexing fails with Neos 8.2 with ApiException in cleanupOldIndicies

### DIFF
--- a/Classes/UpdateAliasJob.php
+++ b/Classes/UpdateAliasJob.php
@@ -21,6 +21,7 @@ use Flowpack\JobQueue\Common\Queue\QueueInterface;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Log\Utility\LogEnvironment;
 use Neos\Flow\Utility\Algorithms;
+use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
 
 class UpdateAliasJob implements JobInterface

--- a/Classes/UpdateAliasJob.php
+++ b/Classes/UpdateAliasJob.php
@@ -137,7 +137,7 @@ class UpdateAliasJob implements JobInterface
                 }
             }
         } catch (ApiException $exception) {
-            $response = json_decode($exception->getResponse(), true, 512, JSON_THROW_ON_ERROR);
+            $response = json_decode($exception->getResponse() instanceof ResponseInterface ? $exception->getResponse()->getBody()->__toString() : (string) $exception->getResponse(), true, 512, JSON_THROW_ON_ERROR);
             if ($response->error instanceof \stdClass) {
                 $this->logger->error(sprintf('Old indices for alias %s could not be removed. ElasticSearch responded with status %s, saying "%s: %s"', $this->indexPostfix, $response->status, $response->error->type, $response->error->reason), LogEnvironment::fromMethodName(__METHOD__));
             } else {


### PR DESCRIPTION
The change tests to see if the getResponse() is an instance of RequestInterface ant then calls ->getBody()->__toString() accordingly, otherwise it implicitly type casts to string.