### PR TITLE
BUGFIX: set targetWorkspaceName to the nodes Workspace if there is no…

### DIFF
--- a/Classes/Indexer/NodeIndexer.php
+++ b/Classes/Indexer/NodeIndexer.php
@@ -105,6 +105,7 @@ class NodeIndexer extends ContentRepositoryAdaptor\Indexer\NodeIndexer
         }
 
         $dimensionCombinations = $this->dimensionService->getDimensionCombinationsForIndexing($node);
+        $targetWorkspaceName = $targetWorkspaceName ?? $node->getWorkspace()->getName();
 
         if (array_filter($dimensionCombinations) === []) {
             $removalJob = new RemovalJob($this->indexNamePostfix, $targetWorkspaceName, $this->nodeAsArray($node));


### PR DESCRIPTION
… targetWorkspaceName passed to the function

It can happen, taht there is no targetWorkspaceName passed to the removeNode() function call. To create the ContentContext a targetWorkspaceName is required for the code to not throw an Exception.